### PR TITLE
Add CMakeLists.txt to make it compatible with the newer build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+idf_component_register(
+        SRCS
+          "src/ps3.c"
+          "src/ps3_spp.c"
+          "src/ps3_parser.c"
+          "src/ps3_l2cap.c"
+        REQUIRES "bt" "nvs_flash"
+        INCLUDE_DIRS src/include
+        PRIV_INCLUDE_DIRS
+          $ENV{IDF_PATH}/components/bt/common/include
+          $ENV{IDF_PATH}/components/bt/host/bluedroid/common/include
+          $ENV{IDF_PATH}/components/bt/host/bluedroid/stack/include
+          $ENV{IDF_PATH}/components/bt/host/bluedroid/stack/l2cap/include
+          #$ENV{IDF_PATH}/components/bt/host/bluedroid/stack/gap/include
+)
+
+set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/bluetooth/esp_ble_mesh/common_components/button
+                         $ENV{IDF_PATH}/examples/bluetooth/esp_ble_mesh/common_components/light_driver
+                         $ENV{IDF_PATH}/examples/bluetooth/esp_ble_mesh/common_components/example_init
+                         $ENV{IDF_PATH}/examples/bluetooth/esp_ble_mesh/common_components/example_nvs)

--- a/examples/Ps3EspIdfHelloWorld/main.c
+++ b/examples/Ps3EspIdfHelloWorld/main.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_chip_info.h"
+#include "ps3.h"
+#include "nvs_flash.h"
+
+void controller_event_cb(ps3_t ps3, ps3_event_t event)
+{
+    if (ps3.status.battery >= ps3_status_battery_high)
+        printf("batt ok\n");
+
+    if (ps3.status.charging)
+        printf("Controller is charging\n");
+
+    if (ps3.button.triangle)
+        printf("Currently pressing the trangle button\n");
+
+    if (ps3.analog.stick.lx < 0)
+        printf("stick left\n");
+
+    if (event.button_down.cross)
+        printf("The user started pressing the X button\n");
+
+    if (event.button_up.cross)
+        printf("The user released the X button\n");
+
+    if (event.analog_changed.stick.lx)
+        printf("The user has moved the left stick sideways\n");
+}
+
+void app_main(void)
+{
+    printf("Hello world!\n");
+
+    ESP_ERROR_CHECK(nvs_flash_init());
+    ps3SetEventCallback(controller_event_cb);
+    uint8_t mac[6] = { 0x44, 0xd8, 0x32, 0xbe, 0x1a, 0xc6 };
+    ps3SetBluetoothMacAddress(mac);
+    ps3Init();
+
+    while (!ps3IsConnected()) {
+        // Prevent the Task Watchdog from triggering
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+        printf("waiting\n");
+    }
+}


### PR DESCRIPTION
I was unable to make the original library work for me with ESP IDF version 5.0.
Although I'm not very familiar with neither old (component.mk) nor new (CMakeLists.txt) build system but I was able to make it work by using CMakeLists.txt from here https://github.com/wzli/SlabRobot/blob/master/firmware/esp32_app/components/esp32-ps3/CMakeLists.txt